### PR TITLE
[FIX] 다음 상대와 매칭 시 금칙어가 초기화되지 않는 현상 해결

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -39,7 +39,7 @@ function setWebSocket(server: http.Server) {
     let roomName: string;
     let time = 120;
     let timeInterval: NodeJS.Timeout | undefined;
-    const forbiddenWord: string = getRandomWord();
+    let forbiddenWord: string;
 
     socket.on("enter_room", () => {
       const filtered = Array.from(getPublicRooms()).filter(
@@ -61,6 +61,8 @@ function setWebSocket(server: http.Server) {
     });
 
     socket.on("send_forbiddenWord", () => {
+      forbiddenWord = getRandomWord();
+
       socket.to(roomName).emit("send_forbiddenWord", forbiddenWord);
     });
 


### PR DESCRIPTION
- 상대에게 금칙어를 전송할 때마다 forbiddenWord 변수에 랜덤한 금칙어를 재할당 함으로써 해결